### PR TITLE
Handle dismissal of in-app browser

### DIFF
--- a/pod_example/Podfile.lock
+++ b/pod_example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - OpacityCore (5.1.2)
+  - OpacityCore (5.1.3)
 
 DEPENDENCIES:
   - OpacityCore (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  OpacityCore: f5c55eace3adc06b64e80b856590b9a6a8c27e6a
+  OpacityCore: c64262bda795918c2952d6e9d116eacb5d4bf80f
 
 PODFILE CHECKSUM: 13404f354c13fb5095aa4a798ef71da45d4bd4f4
 

--- a/src/objc/ModalWebViewController.h
+++ b/src/objc/ModalWebViewController.h
@@ -1,7 +1,8 @@
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
 
-@interface ModalWebViewController : UIViewController <WKNavigationDelegate, NSURLSessionTaskDelegate>
+@interface ModalWebViewController
+    : UIViewController <WKNavigationDelegate, NSURLSessionTaskDelegate>
 
 - (instancetype)initWithRequest:(NSMutableURLRequest *)request;
 - (void)close;

--- a/src/objc/ModalWebViewController.mm
+++ b/src/objc/ModalWebViewController.mm
@@ -13,20 +13,6 @@
 @end
 
 @implementation ModalWebViewController
-
-- (void)openRequest:(NSMutableURLRequest *)request {
-  _request = request;
-  [self.webView loadRequest:_request];
-}
-
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request {
-  self = [super init];
-  if (self) {
-    _request = request;
-  }
-  return self;
-}
-
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -72,6 +58,34 @@
                            target:self
                            action:@selector(close)];
   self.navigationItem.rightBarButtonItem = closeButton;
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+  // Check if the controller or its navigation controller is being dismissed
+  if (self.isBeingDismissed || self.navigationController.isBeingDismissed) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    [dict setObject:@"close" forKey:@"event"];
+    [dict setObject:[NSString stringWithFormat:@"%f", [[NSDate date] timeIntervalSince1970]] forKey:@"id"];
+    
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
+    NSString *payload = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    
+    opacity_core::emit_webview_event([payload UTF8String]);
+  }
+}
+
+- (void)openRequest:(NSMutableURLRequest *)request {
+  _request = request;
+  [self.webView loadRequest:_request];
+}
+
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request {
+  self = [super init];
+  if (self) {
+    _request = request;
+  }
+  return self;
 }
 
 - (void)close {

--- a/src/objc/OpacityIOSHelper.mm
+++ b/src/objc/OpacityIOSHelper.mm
@@ -48,11 +48,9 @@ void ios_present_webview() {
 
     modalWebVC = [[ModalWebViewController alloc] initWithRequest:request];
 
-    // Create a navigation controller to embed the modal web view controller
     navController =
         [[UINavigationController alloc] initWithRootViewController:modalWebVC];
 
-    // Get the topmost view controller
     UIViewController *topController = topMostViewController();
 
     [topController presentViewController:navController
@@ -105,7 +103,7 @@ const char *get_battery_status() {
 const char *get_carrier_name() {
   CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   NSDictionary<NSString *, CTCarrier *> *carriers =
-  [networkInfo serviceSubscriberCellularProviders];
+      [networkInfo serviceSubscriberCellularProviders];
   CTCarrier *carrier = carriers.allValues.firstObject;
   NSString *carrierName = [carrier carrierName];
   const char *name = [carrierName UTF8String];
@@ -115,7 +113,7 @@ const char *get_carrier_name() {
 const char *get_carrier_mcc() {
   CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   NSDictionary<NSString *, CTCarrier *> *carriers =
-  [networkInfo serviceSubscriberCellularProviders];
+      [networkInfo serviceSubscriberCellularProviders];
   CTCarrier *carrier = carriers.allValues.firstObject;
   NSString *mcc = [carrier mobileCountryCode];
   const char *mccCString = [mcc UTF8String];
@@ -125,7 +123,7 @@ const char *get_carrier_mcc() {
 const char *get_carrier_mnc() {
   CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   NSDictionary<NSString *, CTCarrier *> *carriers =
-  [networkInfo serviceSubscriberCellularProviders];
+      [networkInfo serviceSubscriberCellularProviders];
   CTCarrier *carrier = carriers.allValues.firstObject;
   NSString *mnc = [carrier mobileNetworkCode];
   const char *mncCString = [mnc UTF8String];


### PR DESCRIPTION
Instead of using the close button one can use a swipe down gesture. This was not being caught properly and caused the lua script to spin out of control. This should now be correctly handled and the correct event emitted.