### PR TITLE
feat: get cookies for any domain/url

### DIFF
--- a/src/objc/ModalWebViewController.h
+++ b/src/objc/ModalWebViewController.h
@@ -7,4 +7,5 @@
 - (void)close;
 - (void)openRequest:(NSMutableURLRequest *)request;
 - (NSDictionary *)getBrowserCookiesForCurrentUrl;
+- (NSDictionary *)getBrowserCookiesForUrl:(NSString *)url;
 @end

--- a/src/objc/OpacityIOSHelper.h
+++ b/src/objc/OpacityIOSHelper.h
@@ -11,14 +11,16 @@
 #endif
 
 #ifdef __cplusplus
-namespace opacity {
+namespace opacity
+{
 #endif
 
-OBJC_EXTERN void ios_prepare_request(const char *url);
-OBJC_EXTERN void ios_set_request_header(const char *key, const char *value);
-OBJC_EXTERN void ios_present_webview();
-OBJC_EXTERN void ios_close_webview();
-OBJC_EXTERN const char *ios_get_browser_cookies_for_current_url();
+	OBJC_EXTERN void ios_prepare_request(const char *url);
+	OBJC_EXTERN void ios_set_request_header(const char *key, const char *value);
+	OBJC_EXTERN void ios_present_webview();
+	OBJC_EXTERN void ios_close_webview();
+	OBJC_EXTERN const char *ios_get_browser_cookies_for_current_url();
+	OBJC_EXTERN const char *ios_get_browser_cookies_for_url(const char *url);
 
 #ifdef __cplusplus
 } // namespace opacity

--- a/src/objc/OpacityIOSHelper.mm
+++ b/src/objc/OpacityIOSHelper.mm
@@ -69,6 +69,27 @@ void ios_close_webview() {
   });
 }
 
+const char *ios_get_browser_cookies_for_url(const char *url) {
+  NSLog(@"Getting browser cookies for URL: %s", url);
+  NSString *urlString = [NSString stringWithUTF8String:url];
+  NSDictionary *cookies = [modalWebVC getBrowserCookiesForUrl:urlString];
+
+  // Convert the dictionary to JSON string
+  NSError *error;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:cookies
+                                                     options:0
+                                                       error:&error];
+  if (!jsonData) {
+    NSLog(@"Error serializing cookies to JSON: %@", error);
+    return "";
+  }
+
+  // Convert JSON data to C string and return
+  NSString *jsonString = [[NSString alloc] initWithData:jsonData
+                                               encoding:NSUTF8StringEncoding];
+  return [jsonString UTF8String];
+}
+
 const char *ios_get_browser_cookies_for_current_url() {
   if (modalWebVC == nil) {
     return "";


### PR DESCRIPTION
This PR still needs some help with naming
Usually we query by domain, not actual url, thus `.www.linkedin.com` is a valid domain (with subdomains included), rather than a URL