### PR TITLE
Hrvdm/close hook

### DIFF
--- a/src/objc/ModalWebViewController.mm
+++ b/src/objc/ModalWebViewController.mm
@@ -375,7 +375,7 @@
 - (void)userContentController:(WKUserContentController *)userContentController
       didReceiveScriptMessage:(WKScriptMessage *)message {
   if ([message.name isEqualToString:@"windowCloseCalled"]) {
-    opacity_core::emit_webview_event("{\"event\": \"no_op_close\"}");
+    opacity_core::emit_webview_event("{\"event\": \"window.close\"}");
   }
 }
 


### PR DESCRIPTION
- When a browser window called window.close execution would fail which broke the epic flow, this hooks window.close to no op
- Bumped opacity-core to 5.5.5 in podlock